### PR TITLE
Composer 2.0 functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=5.6",
     "contao/core-bundle": "~4.4",
-    "contao-community-alliance/composer-plugin": "~3.0"
+    "contao-community-alliance/composer-plugin": "^3.0"
   },
   "suggest": {
     "components/font-awesome": "Font awesome components package",


### PR DESCRIPTION
Change version constraint of composer-plugin from ~3.0 to ^3.0 to allow update to 3.1. In version 3.1 Composer 2.0 can be used.