### PR TITLE
allow contao 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^7.2 || ^8.0",
-    "contao/core-bundle": "^4.9",
+    "contao/core-bundle": "^4.9 || ^5.0",
     "symfony/config": "^4.4 || ^5.0",
     "symfony/dependency-injection": "^4.4 || ^5.0",
     "symfony/http-kernel": "^4.4.13 || ^5.1.5"

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "contao/core-bundle": "^4.9 || ^5.0",
-    "symfony/config": "^4.4 || ^5.0",
-    "symfony/dependency-injection": "^4.4 || ^5.0",
-    "symfony/http-kernel": "^4.4.13 || ^5.1.5"
+    "symfony/config": "^4.4 || ^5.0 || ^6.0",
+    "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+    "symfony/http-kernel": "^4.4.13 || ^5.1.5 || ^6.0"
   },
   "conflict": {
     "contao/manager-plugin": "<2.0 || >=3.0"


### PR DESCRIPTION
I couldn't find any bugs, so there should be nothing against supporting Contao 5. If you want I could still change the use of the src/Resource folder, but then you would have to throw out Contao 4.9 and only support 4.13 and Contao 5.0.